### PR TITLE
fix: load same model twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ cmake-build-release
 cmake-build-minsizerel
 cmake-build-relwithdebinfo
 .gradle
+.clangd
+.vscode
+compile_commands.json

--- a/easy3d/viewer/viewer.cpp
+++ b/easy3d/viewer/viewer.cpp
@@ -1072,7 +1072,7 @@ namespace easy3d {
 
     Model *Viewer::add_model(const std::string &file_name, bool create_default_drawables) {
         for (auto m : models_) {
-            if (m->name() == file_name) {
+            if (file_system::convert_to_native_style(m->name()) == file_system::convert_to_native_style(file_name)) {
                 LOG(WARNING) << "model has already been added to the viewer: " << file_name;
                 return m;
             }


### PR DESCRIPTION
In the following code in [tutorials/Tutorial_201_Viewer_imgui/main.cpp](https://github.com/LiangliangNan/Easy3D/blob/b2c1e60ccffe22cdd913133a3ba2232f5ee18b2b/tutorials/Tutorial_201_Viewer_imgui/main.cpp#L40) we load a model using unix-like path
```cpp
int main(int argc, char** argv) {
    // Initialize logging.
    logging::initialize();

    const std::string file_name = resource::directory() + "/data/easy3d.ply";
    ViewerImGui viewer("Tutorial_201_viewer_imgui");

    if (!viewer.add_model(file_name)) {
        LOG(ERROR) << "Error: failed to load model. Please make sure the file exists and format is correct.";
        return EXIT_FAILURE;
    }

    viewer.resize(800, 600);
    return viewer.run();
}
```

If we load this file again with `File->Open` on windows we will get a windows style path, This model will be loaded twice since the two path string are not the same.