### PR TITLE
Run windeppoyqt after build mapple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ cmake-build-release
 cmake-build-minsizerel
 cmake-build-relwithdebinfo
 .gradle
+.clangd
+.cache
+.vscode
+compile_commands.json

--- a/applications/Mapple/CMakeLists.txt
+++ b/applications/Mapple/CMakeLists.txt
@@ -147,6 +147,11 @@ if (WIN32 OR MSVC)
     # if you want to get rid of the (system) console, use
     #	add_executable( ${PROJECT_NAME} WIN32 ${${PROJECT_NAME}_HEADERS} ${${PROJECT_NAME}_SOURCES} ${${PROJECT_NAME}_FORMS} ${${PROJECT_NAME}_RESOURCES} )
     #       target_link_libraries( ${PROJECT_NAME} Qt5::WinMain )
+    add_custom_command(
+        TARGET ${PROJECT_NAME}
+        POST_BUILD
+        COMMAND ${WINDEPLOYQT} --no-translations --verbose 0 $<TARGET_FILE:${PROJECT_NAME}>
+    )
 elseif (APPLE)
     function(resource VAR SOURCE_PATH DESTINATION PATTERN)
         file(GLOB_RECURSE _LIST CONFIGURE_DEPENDS ${SOURCE_PATH}/${PATTERN})

--- a/applications/Mapple/resources/Mapple.rc
+++ b/applications/Mapple/resources/Mapple.rc
@@ -1,4 +1,4 @@
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-IDI_ICON_MAIN    ICON    "Mapple.ico"
+IDI_ICON_MAIN    ICON    "icons/Mapple.ico"
 

--- a/cmake/UseQt5.cmake
+++ b/cmake/UseQt5.cmake
@@ -75,6 +75,7 @@ if (QT5_FOUND)
     # Starting with the QtCore lib, find the bin and root directories
     get_target_property(QT5_LIB_LOCATION Qt5::Core LOCATION_${CMAKE_BUILD_TYPE})
     get_filename_component(QT_BINARY_DIR ${QT5_LIB_LOCATION} DIRECTORY)
+    set(WINDEPLOYQT ${QT_BINARY_DIR}/windeployqt.exe)
 
     # Apple uses frameworks - move up until we get to the base directory to set the bin directory properly
     if (APPLE)


### PR DESCRIPTION
* Run `windeployqt.exe` after build **Mapple**
* Fix a compile error on windows related to a resource file

⚠️ I'm not sure whether the change in `applications/Mapple/resources/Mapple.rc` will cause some trouble on other platforms.