### PR TITLE
Search only the Boost Graph Library component

### DIFF
--- a/easy3d/algo/CMakeLists.txt
+++ b/easy3d/algo/CMakeLists.txt
@@ -80,7 +80,7 @@ add_module(${module} "${${module}_headers}" "${${module}_sources}" "${private_de
 target_include_directories(easy3d_${module} PRIVATE ${Easy3D_THIRD_PARTY}/eigen ${Easy3D_THIRD_PARTY}/ransac)
 
 # It's "Boost", not "BOOST" or "boost". Case matters.
-find_package(Boost)
+find_package(Boost COMPONENTS graph)
 if (Boost_FOUND)
     target_include_directories(easy3d_${module} PRIVATE ${Boost_INCLUDE_DIRS})
     target_compile_definitions(easy3d_${module} PRIVATE HAS_BOOST)


### PR DESCRIPTION
Only some boost packages can be installed on the computer. If only boost-program-options is available, then the program will not build: HAS_BOOST will be TRUE, but the header file "boost/adjacency_list.hpp" will not be available. My little edit corrects this situation.