### PR TITLE
fix: Applies fixes to build using clang compiler

### DIFF
--- a/3rd_party/poisson/Ply.h
+++ b/3rd_party/poisson/Ply.h
@@ -340,7 +340,7 @@ public:
 	PlyOrientedVertex( void ) { ; }
 	PlyOrientedVertex( Point3D< Real > p , Point3D< Real > n ) : point(p) , normal(n) { ; }
   	PlyOrientedVertex operator + ( PlyOrientedVertex p ) const { return PlyOrientedVertex( point+p.point , normal+p.normal ); }
-	PlyOrientedVertex operator - ( PlyOrientedVertex p ) const { return PlyOrientedVertex( point-p.value , normal-p.normal ); }
+	PlyOrientedVertex operator - ( PlyOrientedVertex p ) const { return PlyOrientedVertex( point-p.point , normal-p.normal ); }
 	template< class _Real > PlyOrientedVertex operator * ( _Real s ) const { return PlyOrientedVertex( point*s , normal*s ); }
 	template< class _Real > PlyOrientedVertex operator / ( _Real s ) const { return PlyOrientedVertex( point/s , normal/s ); }
 	PlyOrientedVertex& operator += ( PlyOrientedVertex p ) { point += p.point , normal += p.normal ; return *this; }
@@ -386,7 +386,7 @@ public:
 		}
 
 	  	_PlyColorVertex operator + ( _PlyColorVertex p ) const { return _PlyColorVertex( point+p.point , color+p.color ); }
-		_PlyColorVertex operator - ( _PlyColorVertex p ) const { return _PlyColorVertex( point-p.value , color-p.color ); }
+		_PlyColorVertex operator - ( _PlyColorVertex p ) const { return _PlyColorVertex( point-p.point , color-p.color ); }
 		template< class _Real > _PlyColorVertex operator * ( _Real s ) const { return _PlyColorVertex( point*s , color*s ); }
 		template< class _Real > _PlyColorVertex operator / ( _Real s ) const { return _PlyColorVertex( point/s , color/s ); }
 		_PlyColorVertex& operator += ( _PlyColorVertex p ) { point += p.point , color += p.color ; return *this; }

--- a/3rd_party/poisson/SparseMatrix.inl
+++ b/3rd_party/poisson/SparseMatrix.inl
@@ -193,12 +193,6 @@ void SparseMatrix< T >::SetRowSize( int row , int count )
 
 
 template<class T>
-void SparseMatrix<T>::SetZero()
-{
-	Resize(this->m_N, this->m_M);
-}
-
-template<class T>
 SparseMatrix<T> SparseMatrix<T>::operator * (const T& V) const
 {
 	SparseMatrix<T> M(*this);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ install(DIRECTORY
         "${Easy3D_INSTALL_RESOURCE_DIR}")
 
 install(FILES
-        "${Easy3D_ROOT}/ReadMe.md"
+	"${Easy3D_ROOT}/README.md"
         "${Easy3D_ROOT}/LICENSE"
         DESTINATION
         "${CMAKE_INSTALL_PREFIX}"

--- a/easy3d/util/version.h
+++ b/easy3d/util/version.h
@@ -59,7 +59,7 @@ namespace easy3d {
 #define EASY3D_VERSION_NR 1020601
 
 /// Easy3D release date, in the format YYYYMMDD.
-#define EASY3D_RELEASE_DATE 20250121
+#define EASY3D_RELEASE_DATE 20250123
 
 
 #endif  // EASY3D_UTIL_VERSION_H


### PR DESCRIPTION
Compiling with GCC works fine but fails with Clang. This MR fixes clang/libc++ builds. (Tested on llvm version 20)
